### PR TITLE
[FEATURE] Initialize BackendRouter for FunctionalTests

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -540,6 +540,7 @@ class Testbase
             ->baseSetup()
             ->loadConfigurationAndInitialize(true)
             ->loadTypo3LoadedExtAndExtLocalconf(true)
+            ->initializeBackendRouter()
             ->setFinalCachingFrameworkCacheConfiguration()
             ->defineLoggingAndExceptionConstants()
             ->unsetReservedGlobalVariables();


### PR DESCRIPTION
The UriBuilder will fail if backend routes are not loaded.